### PR TITLE
protect various dirs/files

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,10 @@
+# Exclude access to the following directories / files
+RedirectMatch 403 /vendor
+RedirectMatch 403 /composer.lock
+RedirectMatch 403 /composer.json
+RedirectMatch 403 /config
+RedirectMatch 403 /docs
+RedirectMatch 403 /public
+RedirectMatch 403 /src
+RedirectMatch 403 /.gitignore
+RedirectMatch 403 /README.md


### PR DESCRIPTION
Fixes #26 

Figured it had been long enough since my last PR ;)

This .htaccess file will stop people from visiting the routes (and sub directories) specified. It requires an apache server to be upheld, so running `php -S localhost:8081` won't enforce this; but, using xampp & running the project from the htdocs folder will updhold the rules since that's an apache web server