### PR TITLE
53

### DIFF
--- a/public/views/user/members.php
+++ b/public/views/user/members.php
@@ -1,17 +1,16 @@
 <div class="card-columns">
-    <?php /** @var \App\Models\User\User $member */ ?>
     <?php foreach ($data['members'] as $member) : ?>
         <div class="card">
-            <div class="card-header d-flex justify-content-between">
-                <span><?= $member->getUsername() ?></span>
+            <div class="card-body d-flex justify-content-between">
+                <span><?= $member['username'] ?></span>
                 <span>
-                    <a target="_blank" href="/User/Details/<?= $member->getID() ?>">
+                    <a target="_blank" href="/User/Details/<?= $member['user_id'] ?>">
                         <i class="fas fa-eye"></i>
                     </a>
                 </span>
             </div>
-            <div class="card-footer">
-                Total level: <?= $member->getTotalLevel() ?: 'N/A' ?>
+            <div class="card-footer text-muted">
+                Last active: <?= $member['last_active'] ?>
             </div>
         </div>
     <?php endforeach; ?>

--- a/src/Models/User/User.php
+++ b/src/Models/User/User.php
@@ -3,6 +3,7 @@
 namespace App\Models\User;
 
 use App\Utils\Http\Request;
+use Carbon\Carbon;
 use PDO;
 use App\Utils\Http\Session;
 
@@ -132,21 +133,25 @@ class User
     }
     
     /**
-     * Function returns an active list of members
-     * Note: will convert database records into User objects
-     *
      * @return User[]
      */
     public static function getMembers(): array
     {
         $database = getDatabase();
-        $sql = $database->query("SELECT user_id FROM user");
+        $sql = $database->query("SELECT user_id, u.username, us.date_added
+                                FROM user u
+                                LEFT JOIN user_skills us ON u.username = us.username AND us.skill_name = 'Overall'");
         $members = $sql->fetchAll(PDO::FETCH_ASSOC);
         
         $users = [];
         foreach ($members as $member) {
-            $users[] = new self($member['user_id']);
+            $users[] = [
+                'user_id'     => $member['user_id'],
+                'username'    => $member['username'],
+                'last_active' => $member['date_added'] ? Carbon::create($member['date_added'])->format('m/d/y') : 'N/A'
+            ];
         }
+        
         return $users;
     }
     


### PR DESCRIPTION
Fixes #53 

Problem was, when we clicked the 'members' page, it'd iterate all of our current users and call hiscores API for each and it was a ton of overhead. I've updated this to omit that and just be a simple data return; I changed the total level at the bottom to a 'last active' based on our last collected skill date from the hiscores