### PR TITLE
mount image composer install dir

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       - "80:80"
     volumes:
       - ./server:/var/www/html
+      - /var/www/html/vendor
       - ./docker/php/xdebug.ini:/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
       - ./docker/php/error_reporting.ini:/usr/local/etc/php/conf.d/error_reporting.ini
     depends_on:


### PR DESCRIPTION
Fixes #53 

Clean re-install this into a new dir, run `docker compose up` after populating the `.env` file and you should get a working local on localhost:8080 after containers are up